### PR TITLE
Automated Changelog Entry for 0.1.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,27 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0
+
+([Full Changelog](https://github.com/jtpio/jupyterlab-filesystem-access/compare/cec8cbbce5042c8f7d6dce07265fba5a5317c8df...bbc9d3597d0694178d96c00268ff6d501b6a1268))
+
+### Enhancements made
+
+- Basic support for saving a file [#5](https://github.com/jtpio/jupyterlab-filesystem-access/pull/5) ([@jtpio](https://github.com/jtpio))
+
+### Maintenance and upkeep improvements
+
+- Reset version [#7](https://github.com/jtpio/jupyterlab-filesystem-access/pull/7) ([@jtpio](https://github.com/jtpio))
+- Rename to `jupyterlab-filesystem-access` [#6](https://github.com/jtpio/jupyterlab-filesystem-access/pull/6) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Add disclaimer to README.md [#4](https://github.com/jtpio/jupyterlab-filesystem-access/pull/4) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-08&to=2022-04-09&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-filesystem-access+involves%3Ajtpio+updated%3A2022-04-08..2022-04-09&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jtpio/jupyterlab-filesystem-access  |
| Branch  | main  |
| Version Spec | 0.1.0 |
