### PR TITLE
Automated Changelog Entry for 0.1.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.1
+
+([Full Changelog](https://github.com/jtpio/jupyterlab-filesystem-access/compare/v0.1.0...3d9774618956b282ebb9f3498c6e0f3731dea86d))
+
+### Bugs fixed
+
+- Fix saving Notebooks [#9](https://github.com/jtpio/jupyterlab-filesystem-access/pull/9) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-09&to=2022-04-09&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-filesystem-access+involves%3Ajtpio+updated%3A2022-04-09..2022-04-09&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0
 
 ([Full Changelog](https://github.com/jtpio/jupyterlab-filesystem-access/compare/cec8cbbce5042c8f7d6dce07265fba5a5317c8df...bbc9d3597d0694178d96c00268ff6d501b6a1268))
@@ -24,5 +40,3 @@
 ([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-08&to=2022-04-09&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-filesystem-access+involves%3Ajtpio+updated%3A2022-04-08..2022-04-09&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jtpio/jupyterlab-filesystem-access  |
| Branch  | main  |
| Version Spec | 0.1.1 |
| Since | v0.1.0 |