### PR TITLE
Automated Changelog Entry for 0.2.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.0
+
+([Full Changelog](https://github.com/jtpio/jupyterlab-filesystem-access/compare/v0.1.1...b776fa853b8e6a3a6a3990278a9987f56f6e77a5))
+
+### Enhancements made
+
+- Add support opening subdirs [#11](https://github.com/jtpio/jupyterlab-filesystem-access/pull/11) ([@martinRenou](https://github.com/martinRenou))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-09&to=2022-04-11&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-filesystem-access+involves%3Ajtpio+updated%3A2022-04-09..2022-04-11&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-filesystem-access+involves%3AmartinRenou+updated%3A2022-04-09..2022-04-11&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.1
 
 ([Full Changelog](https://github.com/jtpio/jupyterlab-filesystem-access/compare/v0.1.0...3d9774618956b282ebb9f3498c6e0f3731dea86d))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-09&to=2022-04-09&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-filesystem-access+involves%3Ajtpio+updated%3A2022-04-09..2022-04-09&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.0
 


### PR DESCRIPTION
Automated Changelog Entry for 0.2.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jtpio/jupyterlab-filesystem-access  |
| Branch  | main  |
| Version Spec | 0.2.0 |
| Since | v0.1.1 |